### PR TITLE
Switch test property setters to init

### DIFF
--- a/Tests/Evoogle.Core.Tests/Cloneable/DeepCopyTests.cs
+++ b/Tests/Evoogle.Core.Tests/Cloneable/DeepCopyTests.cs
@@ -22,7 +22,7 @@ public class DeepCopyTests(ITestOutputHelper output) : XUnitTests(output)
     {
         #region User Supplied Properties
         [JsonConverter(typeof(LambdaExpressionJsonConverter))]
-        public LambdaExpression? ExpectedSafeDeepCopyAccessorExpression { get; set; }
+        public LambdaExpression? ExpectedSafeDeepCopyAccessorExpression { get; init; }
         #endregion
 
         #region Constructors

--- a/Tests/Evoogle.Core.Tests/Coercion/CoerceTest.cs
+++ b/Tests/Evoogle.Core.Tests/Coercion/CoerceTest.cs
@@ -50,14 +50,14 @@ public class CoerceTest : XUnitTest
 public abstract class CoerceTest<TInput, TOutput> : CoerceTest
 {
     #region User Supplied Properties
-    public TInput? Input { get; set; }
+    public TInput? Input { get; init; }
 
     [JsonConverter(typeof(ExpressionFuncJsonConverter<TypeCoercionContext>))]
-    public Expression<Func<TypeCoercionContext>>? ContextFactoryExpression { get; set; }
+    public Expression<Func<TypeCoercionContext>>? ContextFactoryExpression { get; init; }
 
-    public bool ExpectedResult { get; set; }
+    public bool ExpectedResult { get; init; }
 
-    public TOutput? ExpectedOutput { get; set; }
+    public TOutput? ExpectedOutput { get; init; }
     #endregion
 
     #region Calculated Properties

--- a/Tests/Evoogle.Core.Tests/Extension/ExtensibleTests.cs
+++ b/Tests/Evoogle.Core.Tests/Extension/ExtensibleTests.cs
@@ -47,15 +47,15 @@ public class ExtensibleTests(ITestOutputHelper output) : XUnitTests(output)
     {
         #region User Supplied Properties
         [JsonConverter(typeof(ExpressionFuncJsonConverter<TestExtensible>))]
-        public Expression<Func<TestExtensible>> ExtensibleFactoryExpression { get; set; } = null!;
+        public Expression<Func<TestExtensible>> ExtensibleFactoryExpression { get; init; } = null!;
 
         [JsonConverter(typeof(ExpressionActionJsonConverter<TestExtensible>))]
-        public Expression<Action<TestExtensible>>? ExtensibleMutateExpression { get; set; }
+        public Expression<Action<TestExtensible>>? ExtensibleMutateExpression { get; init; }
 
-        public bool ExpectedResult { get; set; }
-        public bool ExpectedArgumentNullExceptionThrown { get; set; }
+        public bool ExpectedResult { get; init; }
+        public bool ExpectedArgumentNullExceptionThrown { get; init; }
 
-        public TestExtension? ExpectedExtension { get; set; }
+        public TestExtension? ExpectedExtension { get; init; }
         #endregion
 
         #region Calculated Properties

--- a/Tests/Evoogle.Core.Tests/Extensions/DotNetDictionaryExtensionTests.cs
+++ b/Tests/Evoogle.Core.Tests/Extensions/DotNetDictionaryExtensionTests.cs
@@ -15,10 +15,10 @@ public class DotNetDictionaryExtensionTests(ITestOutputHelper output) : XUnitTes
     public class GetValueUnitTest<TKey, TValue> : XUnitTest
     {
         #region User Supplied Properties
-        public IDictionary<TKey, TValue> Dictionary { get; set; } = null!;
-        public TKey Key { get; set; } = default!;
-        public TValue? ExpectedValue { get; set; }
-        public bool ExpectedExceptionThrown { get; set; }
+        public IDictionary<TKey, TValue> Dictionary { get; init; } = null!;
+        public TKey Key { get; init; } = default!;
+        public TValue? ExpectedValue { get; init; }
+        public bool ExpectedExceptionThrown { get; init; }
         #endregion
 
         #region Calculated Properties

--- a/Tests/Evoogle.Core.Tests/Extensions/DotNetEnumerableExtensionTests.cs
+++ b/Tests/Evoogle.Core.Tests/Extensions/DotNetEnumerableExtensionTests.cs
@@ -15,8 +15,8 @@ public class DotNetEnumerableExtensionTests(ITestOutputHelper output) : XUnitTes
     private class EmptyIfNullUnitTest<T> : XUnitTest
     {
         #region User Supplied Properties
-        public IEnumerable<T>? Original { get; set; }
-        public IEnumerable<T> Expected { get; set; } = null!;
+        public IEnumerable<T>? Original { get; init; }
+        public IEnumerable<T> Expected { get; init; } = null!;
         #endregion
 
         #region Calculated Properties
@@ -60,8 +60,8 @@ public class DotNetEnumerableExtensionTests(ITestOutputHelper output) : XUnitTes
     private class IsNullOrEmptyUnitTest<T> : XUnitTest
     {
         #region User Supplied Properties
-        public IEnumerable<T>? Original { get; set; }
-        public bool Expected { get; set; }
+        public IEnumerable<T>? Original { get; init; }
+        public bool Expected { get; init; }
         #endregion
 
         #region Calculated Properties
@@ -101,8 +101,8 @@ public class DotNetEnumerableExtensionTests(ITestOutputHelper output) : XUnitTes
     private class SafeCastUnitTest<TFrom, TTo> : XUnitTest
     {
         #region User Supplied Properties
-        public IEnumerable<TFrom>? Original { get; set; }
-        public IEnumerable<TTo> Expected { get; set; } = null!;
+        public IEnumerable<TFrom>? Original { get; init; }
+        public IEnumerable<TTo> Expected { get; init; } = null!;
         #endregion
 
         #region Calculated Properties
@@ -146,8 +146,8 @@ public class DotNetEnumerableExtensionTests(ITestOutputHelper output) : XUnitTes
     private class SafeToArrayUnitTest<T> : XUnitTest
     {
         #region User Supplied Properties
-        public IEnumerable<T>? Original { get; set; }
-        public T[] Expected { get; set; } = null!;
+        public IEnumerable<T>? Original { get; init; }
+        public T[] Expected { get; init; } = null!;
         #endregion
 
         #region Calculated Properties
@@ -191,8 +191,8 @@ public class DotNetEnumerableExtensionTests(ITestOutputHelper output) : XUnitTes
     private class SafeToListUnitTest<T> : XUnitTest
     {
         #region User Supplied Properties
-        public IEnumerable<T>? Original { get; set; }
-        public IList<T> Expected { get; set; } = null!;
+        public IEnumerable<T>? Original { get; init; }
+        public IList<T> Expected { get; init; } = null!;
         #endregion
 
         #region Calculated Properties
@@ -236,8 +236,8 @@ public class DotNetEnumerableExtensionTests(ITestOutputHelper output) : XUnitTes
     private class SafeToReadOnlyCollectionUnitTest<T> : XUnitTest
     {
         #region User Supplied Properties
-        public IEnumerable<T>? Original { get; set; }
-        public IReadOnlyCollection<T> Expected { get; set; } = null!;
+        public IEnumerable<T>? Original { get; init; }
+        public IReadOnlyCollection<T> Expected { get; init; } = null!;
         #endregion
 
         #region Calculated Properties
@@ -281,8 +281,8 @@ public class DotNetEnumerableExtensionTests(ITestOutputHelper output) : XUnitTes
     private class SafeToReadOnlyListUnitTest<T> : XUnitTest
     {
         #region User Supplied Properties
-        public IEnumerable<T>? Original { get; set; }
-        public IReadOnlyList<T> Expected { get; set; } = null!;
+        public IEnumerable<T>? Original { get; init; }
+        public IReadOnlyList<T> Expected { get; init; } = null!;
         #endregion
 
         #region Calculated Properties

--- a/Tests/Evoogle.Core.Tests/Extensions/DotNetObjectExtensionTests.cs
+++ b/Tests/Evoogle.Core.Tests/Extensions/DotNetObjectExtensionTests.cs
@@ -14,10 +14,10 @@ public class DotNetObjectExtensionTests(ITestOutputHelper output) : XUnitTests(o
     #region Test Classes
     public class SafeToStringTest : XUnitTest
     {
-        public object? Source { get; set; }
-        public string? Expected { get; set; }
-        public string? NullText { get; set; }
-        public string? EmtpyText { get; set; }
+        public object? Source { get; init; }
+        public string? Expected { get; init; }
+        public string? NullText { get; init; }
+        public string? EmtpyText { get; init; }
         private string? Actual { get; set; }
 
         protected override void Act() => this.Actual = this.Source!.SafeToString(this.NullText!, this.EmtpyText!);

--- a/Tests/Evoogle.Core.Tests/Extensions/DotNetStringExtensionTests.cs
+++ b/Tests/Evoogle.Core.Tests/Extensions/DotNetStringExtensionTests.cs
@@ -15,12 +15,12 @@ public class DotNetStringExtensionTests(ITestOutputHelper output) : XUnitTests(o
     public class MaskTest : XUnitTest
     {
         #region User Supplied Properties
-        public string? Source { get; set; }
-        public string? Expected { get; set; }
-        public char MaskChar { get; set; } = '*';
-        public int UnmaskedLeftCount { get; set; } = 1;
-        public int? UnmaskedRightCount { get; set; } = null;
-        public int MinMaskedCount { get; set; } = 8;
+        public string? Source { get; init; }
+        public string? Expected { get; init; }
+        public char MaskChar { get; init; } = '*';
+        public int UnmaskedLeftCount { get; init; } = 1;
+        public int? UnmaskedRightCount { get; init; } = null;
+        public int MinMaskedCount { get; init; } = 8;
         #endregion
 
         #region Calculated Properties
@@ -45,8 +45,8 @@ public class DotNetStringExtensionTests(ITestOutputHelper output) : XUnitTests(o
 
     public class RemoveWhitespaceTest : XUnitTest
     {
-        public string? Source { get; set; }
-        public string? Expected { get; set; }
+        public string? Source { get; init; }
+        public string? Expected { get; init; }
         private string? Actual { get; set; }
 
         protected override void Act() => this.Actual = this.Source!.RemoveWhitespace();

--- a/Tests/Evoogle.Core.Tests/Json/EnumJsonConverterTests.cs
+++ b/Tests/Evoogle.Core.Tests/Json/EnumJsonConverterTests.cs
@@ -19,9 +19,9 @@ public class EnumJsonConverterTests(ITestOutputHelper output) : XUnitTests(outpu
         where TEnum : struct, Enum
     {
         #region User Supplied Properties
-        public string? SourceJson { get; set; }
-        public TEnum? ExpectedEnum { get; set; }
-        public string? ExpectedException { get; set; }
+        public string? SourceJson { get; init; }
+        public TEnum? ExpectedEnum { get; init; }
+        public string? ExpectedException { get; init; }
         #endregion
 
         #region Calculated Properties
@@ -88,8 +88,8 @@ public class EnumJsonConverterTests(ITestOutputHelper output) : XUnitTests(outpu
         where TEnum : struct, Enum
     {
         #region User Supplied Properties
-        public TEnum? SourceEnum { get; set; }
-        public string? ExpectedJson { get; set; }
+        public TEnum? SourceEnum { get; init; }
+        public string? ExpectedJson { get; init; }
         #endregion
 
         #region Calculated Properties

--- a/Tests/Evoogle.Core.Tests/Json/TypeJsonConverterTests.cs
+++ b/Tests/Evoogle.Core.Tests/Json/TypeJsonConverterTests.cs
@@ -17,9 +17,9 @@ public class TypeJsonConverterTests(ITestOutputHelper output) : XUnitTests(outpu
     public class JsonDeserializeTest : XUnitTest
     {
         #region User Supplied Properties
-        public string? SourceJson { get; set; }
-        public Type? ExpectedType { get; set; }
-        public string? ExpectedException { get; set; }
+        public string? SourceJson { get; init; }
+        public Type? ExpectedType { get; init; }
+        public string? ExpectedException { get; init; }
         #endregion
 
         #region Calculated Properties
@@ -85,8 +85,8 @@ public class TypeJsonConverterTests(ITestOutputHelper output) : XUnitTests(outpu
     public class JsonSerializeTest : XUnitTest
     {
         #region User Supplied Properties
-        public Type? SourceType { get; set; }
-        public string? ExpectedJson { get; set; }
+        public Type? SourceType { get; init; }
+        public string? ExpectedJson { get; init; }
         #endregion
 
         #region Calculated Properties

--- a/Tests/Evoogle.Core.Tests/Json/Utf8JsonWriterExensionTests.cs
+++ b/Tests/Evoogle.Core.Tests/Json/Utf8JsonWriterExensionTests.cs
@@ -23,9 +23,9 @@ public class Utf8JsonWriterExensionTests(ITestOutputHelper output) : XUnitTests(
     {
         #region User Supplied Properties
         [JsonConverter(typeof(ExpressionActionJsonConverter<Utf8JsonWriter>))]
-        public Expression<Action<Utf8JsonWriter>> WritePropertyExpression { get; set; } = null!;
+        public Expression<Action<Utf8JsonWriter>> WritePropertyExpression { get; init; } = null!;
 
-        public string ExpectedJson { get; set; } = null!;
+        public string ExpectedJson { get; init; } = null!;
         #endregion
 
         #region Calculated Properties

--- a/Tests/Evoogle.Core.Tests/NTree/NodeTests.cs
+++ b/Tests/Evoogle.Core.Tests/NTree/NodeTests.cs
@@ -20,13 +20,13 @@ public class NodeTests(ITestOutputHelper output) : XUnitTests(output)
     {
         #region User Supplied Properties
         [JsonConverter(typeof(ExpressionFuncJsonConverter<TestNode>))]
-        public Expression<Func<TestNode>> TreeFactoryExpression { get; set; } = null!;
+        public Expression<Func<TestNode>> TreeFactoryExpression { get; init; } = null!;
 
         [JsonConverter(typeof(ExpressionActionJsonConverter<TestNode>))]
-        public Expression<Action<TestNode>> TreeMutateExpression { get; set; } = null!;
+        public Expression<Action<TestNode>> TreeMutateExpression { get; init; } = null!;
 
-        public string ExpectedBeforeTraversal { get; set; } = null!;
-        public string ExpectedAfterTraversal { get; set; } = null!;
+        public string ExpectedBeforeTraversal { get; init; } = null!;
+        public string ExpectedAfterTraversal { get; init; } = null!;
         #endregion
 
         #region Calculated Properties
@@ -83,20 +83,20 @@ public class NodeTests(ITestOutputHelper output) : XUnitTests(output)
     {
         #region User Supplied Properties
         [JsonConverter(typeof(ExpressionFuncJsonConverter<TestNode>))]
-        public Expression<Func<TestNode>> TreeFactoryExpression { get; set; } = null!;
+        public Expression<Func<TestNode>> TreeFactoryExpression { get; init; } = null!;
 
         [JsonConverter(typeof(ExpressionFuncJsonConverter<TestNode>))]
-        public Expression<Func<TestNode>> ChildFactoryExpression { get; set; } = null!;
+        public Expression<Func<TestNode>> ChildFactoryExpression { get; init; } = null!;
 
         [JsonConverter(typeof(ExpressionActionJsonConverter<TestNode, TestNode>))]
-        public Expression<Action<TestNode, TestNode>> TreeMutateExpression { get; set; } = null!;
+        public Expression<Action<TestNode, TestNode>> TreeMutateExpression { get; init; } = null!;
 
         #region Calculated Properties
         private string ActualAfterTraversal { get; set; } = null!;
         #endregion
 
-        public string ExpectedBeforeTraversal { get; set; } = null!;
-        public string ExpectedAfterTraversal { get; set; } = null!;
+        public string ExpectedBeforeTraversal { get; init; } = null!;
+        public string ExpectedAfterTraversal { get; init; } = null!;
         #endregion
 
         #region XUnitTest Methods
@@ -153,12 +153,12 @@ public class NodeTests(ITestOutputHelper output) : XUnitTests(output)
     {
         #region User Supplied Properties
         [JsonConverter(typeof(ExpressionFuncJsonConverter<TestNode>))]
-        public Expression<Func<TestNode>> TreeFactoryExpression { get; set; } = null!;
+        public Expression<Func<TestNode>> TreeFactoryExpression { get; init; } = null!;
 
         [JsonConverter(typeof(ExpressionFuncJsonConverter<TestNode, IEnumerator<TestNode>>))]
-        public Expression<Func<TestNode, IEnumerator<TestNode>>> EnumeratorFactoryExpression { get; set; } = null!;
+        public Expression<Func<TestNode, IEnumerator<TestNode>>> EnumeratorFactoryExpression { get; init; } = null!;
 
-        public string ExpectedTraversal { get; set; } = null!;
+        public string ExpectedTraversal { get; init; } = null!;
         #endregion
 
         #region Calculated Properties

--- a/Tests/Evoogle.Core.Tests/Reflection/PropertyReflectionTests.cs
+++ b/Tests/Evoogle.Core.Tests/Reflection/PropertyReflectionTests.cs
@@ -14,9 +14,9 @@ public class PropertyReflectionTests(ITestOutputHelper output) : XUnitTests(outp
     #region Test Classes
     public class IsStaticTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public string PropertyName { get; set; } = null!;
-        public bool Expected { get; set; }
+        public Type Type { get; init; } = null!;
+        public string PropertyName { get; init; } = null!;
+        public bool Expected { get; init; }
 
         private bool Actual { get; set; }
 

--- a/Tests/Evoogle.Core.Tests/Reflection/StaticReflectionTests.cs
+++ b/Tests/Evoogle.Core.Tests/Reflection/StaticReflectionTests.cs
@@ -17,8 +17,8 @@ public class StaticReflectionTests(ITestOutputHelper output) : XUnitTests(output
     public class GetMemberNameTest : XUnitTest
     {
         #region User Supplied Properties
-        public string Expected { get; set; } = null!;
-        public string Actual { get; set; } = null!;
+        public string Expected { get; init; } = null!;
+        public string Actual { get; init; } = null!;
 
         public static Widget Instance { get; } = new Widget();
         #endregion
@@ -36,8 +36,8 @@ public class StaticReflectionTests(ITestOutputHelper output) : XUnitTests(output
 
     public class GetMemberNameEdgeCaseTest : XUnitTest
     {
-        public string CaseName { get; set; } = null!;
-        public string Expected { get; set; } = null!;
+        public string CaseName { get; init; } = null!;
+        public string Expected { get; init; } = null!;
         public string Actual { get; private set; } = null!;
 
         protected override void Arrange()

--- a/Tests/Evoogle.Core.Tests/Reflection/TypeReflectionTests.cs
+++ b/Tests/Evoogle.Core.Tests/Reflection/TypeReflectionTests.cs
@@ -17,13 +17,13 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
     #region Test Classes
     public class GetBaseTypeTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public Type? ExpectedBaseType { get; set; }
+        public Type Type { get; init; } = null!;
+        public Type? ExpectedBaseType { get; init; }
 
-        public string ExpectedBaseTypeName { get; set; } = null!;
+        public string ExpectedBaseTypeName { get; init; } = null!;
 
-        public Type? ActualBaseType { get; set; }
-        public string ActualBaseTypeName { get; set; } = null!;
+        public Type? ActualBaseType { get; init; }
+        public string ActualBaseTypeName { get; init; } = null!;
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -49,13 +49,13 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class GetBaseTypesTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public IEnumerable<Type> ExpectedBaseTypes { get; set; } = null!;
+        public Type Type { get; init; } = null!;
+        public IEnumerable<Type> ExpectedBaseTypes { get; init; } = null!;
 
-        public string ExpectedBaseTypeNames { get; set; } = null!;
+        public string ExpectedBaseTypeNames { get; init; } = null!;
 
-        public IEnumerable<Type> ActualBaseTypes { get; set; } = null!;
-        public string ActualBaseTypeNames { get; set; } = null!;
+        public IEnumerable<Type> ActualBaseTypes { get; init; } = null!;
+        public string ActualBaseTypeNames { get; init; } = null!;
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -81,7 +81,7 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class GetCompactQualifiedNameTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
+        public Type Type { get; init; } = null!;
         public string ActualCompactQualifiedName { get; private set; } = null!;
         public Type? ReconstructedType { get; private set; }
 
@@ -113,12 +113,12 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class GetConstructorTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public BindingFlags BindingFlags { get; set; }
-        public IEnumerable<Type> ParameterTypes { get; set; } = null!;
-        public bool ExpectedConstructorFound { get; set; }
+        public Type Type { get; init; } = null!;
+        public BindingFlags BindingFlags { get; init; }
+        public IEnumerable<Type> ParameterTypes { get; init; } = null!;
+        public bool ExpectedConstructorFound { get; init; }
 
-        public bool ActualConstructorFound { get; set; }
+        public bool ActualConstructorFound { get; init; }
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -146,11 +146,11 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class GetConstructorsTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public BindingFlags BindingFlags { get; set; }
-        public long ExpectedConstructorCount { get; set; }
+        public Type Type { get; init; } = null!;
+        public BindingFlags BindingFlags { get; init; }
+        public long ExpectedConstructorCount { get; init; }
 
-        public long ActualConstructorCount { get; set; }
+        public long ActualConstructorCount { get; init; }
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -175,12 +175,12 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class GetFieldTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public BindingFlags BindingFlags { get; set; }
-        public string FieldName { get; set; } = null!;
-        public string? ExpectedFieldName { get; set; }
+        public Type Type { get; init; } = null!;
+        public BindingFlags BindingFlags { get; init; }
+        public string FieldName { get; init; } = null!;
+        public string? ExpectedFieldName { get; init; }
 
-        public string? ActualFieldName { get; set; }
+        public string? ActualFieldName { get; init; }
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -215,11 +215,11 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class GetFieldsTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public BindingFlags BindingFlags { get; set; }
-        public IEnumerable<string> ExpectedFieldNames { get; set; } = null!;
+        public Type Type { get; init; } = null!;
+        public BindingFlags BindingFlags { get; init; }
+        public IEnumerable<string> ExpectedFieldNames { get; init; } = null!;
 
-        public IEnumerable<string> ActualFieldNames { get; set; } = null!;
+        public IEnumerable<string> ActualFieldNames { get; init; } = null!;
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -242,13 +242,13 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class GetMethodTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public BindingFlags BindingFlags { get; set; }
-        public IEnumerable<Type> ParameterTypes { get; set; } = null!;
-        public string MethodName { get; set; } = null!;
-        public string? ExpectedMethodName { get; set; }
+        public Type Type { get; init; } = null!;
+        public BindingFlags BindingFlags { get; init; }
+        public IEnumerable<Type> ParameterTypes { get; init; } = null!;
+        public string MethodName { get; init; } = null!;
+        public string? ExpectedMethodName { get; init; }
 
-        public string? ActualMethodName { get; set; }
+        public string? ActualMethodName { get; init; }
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -286,11 +286,11 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class GetMethodsTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public BindingFlags BindingFlags { get; set; }
-        public IEnumerable<string> ExpectedMethodNames { get; set; } = null!;
+        public Type Type { get; init; } = null!;
+        public BindingFlags BindingFlags { get; init; }
+        public IEnumerable<string> ExpectedMethodNames { get; init; } = null!;
 
-        public IEnumerable<string> ActualMethodNames { get; set; } = null!;
+        public IEnumerable<string> ActualMethodNames { get; init; } = null!;
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -316,12 +316,12 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class GetPropertyTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public BindingFlags BindingFlags { get; set; }
-        public string PropertyName { get; set; } = null!;
-        public string? ExpectedPropertyName { get; set; }
+        public Type Type { get; init; } = null!;
+        public BindingFlags BindingFlags { get; init; }
+        public string PropertyName { get; init; } = null!;
+        public string? ExpectedPropertyName { get; init; }
 
-        public string? ActualPropertyName { get; set; }
+        public string? ActualPropertyName { get; init; }
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -356,11 +356,11 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class GetPropertiesTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public BindingFlags BindingFlags { get; set; }
-        public IEnumerable<string> ExpectedPropertyNames { get; set; } = null!;
+        public Type Type { get; init; } = null!;
+        public BindingFlags BindingFlags { get; init; }
+        public IEnumerable<string> ExpectedPropertyNames { get; init; } = null!;
 
-        public IEnumerable<string> ActualPropertyNames { get; set; } = null!;
+        public IEnumerable<string> ActualPropertyNames { get; init; } = null!;
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -383,10 +383,10 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class IsComplexTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public bool Expected { get; set; }
+        public Type Type { get; init; } = null!;
+        public bool Expected { get; init; }
 
-        public bool Actual { get; set; }
+        public bool Actual { get; init; }
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -409,10 +409,10 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class IsEnumerableOfTTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public bool Expected { get; set; }
+        public Type Type { get; init; } = null!;
+        public bool Expected { get; init; }
 
-        public bool Actual { get; set; }
+        public bool Actual { get; init; }
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -435,11 +435,11 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class IsImplementationOfTest : XUnitTest
     {
-        public Type DerivedType { get; set; } = null!;
-        public Type BaseType { get; set; } = null!;
-        public bool Expected { get; set; }
+        public Type DerivedType { get; init; } = null!;
+        public Type BaseType { get; init; } = null!;
+        public bool Expected { get; init; }
 
-        public bool Actual { get; set; }
+        public bool Actual { get; init; }
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -463,10 +463,10 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class IsSimpleTest : XUnitTest
     {
-        public Type Type { get; set; } = null!;
-        public bool Expected { get; set; }
+        public Type Type { get; init; } = null!;
+        public bool Expected { get; init; }
 
-        public bool Actual { get; set; }
+        public bool Actual { get; init; }
 
         #region XUnitTest Methods
         protected override void Arrange()
@@ -489,11 +489,11 @@ public class TypeReflectionTests(ITestOutputHelper output) : XUnitTests(output)
 
     public class IsSubclassOrImplementationOfTest : XUnitTest
     {
-        public Type DerivedType { get; set; } = null!;
-        public Type BaseType { get; set; } = null!;
-        public bool Expected { get; set; }
+        public Type DerivedType { get; init; } = null!;
+        public Type BaseType { get; init; } = null!;
+        public bool Expected { get; init; }
 
-        public bool Actual { get; set; }
+        public bool Actual { get; init; }
 
         #region XUnitTest Methods
         protected override void Arrange()


### PR DESCRIPTION
## Summary
- switch public property setters to `init` in XUnit test classes

## Testing
- `dotnet test --no-build --no-restore` *(fails: package Newtonsoft.Json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686cbbe291808330bcbd360987a3ac31