### PR TITLE
fix: parse lambda expressions properly

### DIFF
--- a/Source/Evoogle.XUnit/Json/ExpressionActionJsonConverter.cs
+++ b/Source/Evoogle.XUnit/Json/ExpressionActionJsonConverter.cs
@@ -30,11 +30,12 @@ public sealed class ExpressionActionJsonConverter<T> : JsonConverter<Expression<
             return null;
 
         var lambda = DynamicExpressionParser.ParseLambda(
+            typeof(Action<T>),
             ParsingConfig.Default,
             false,
-            typeof(Action<T>),
-            body,
-            ParameterExpressions);
+            ParameterExpressions,
+            null,
+            body);
 
         return (Expression<Action<T>>)lambda;
     }
@@ -66,11 +67,12 @@ public sealed class ExpressionActionJsonConverter<T1, T2> : JsonConverter<Expres
             return null;
 
         var lambda = DynamicExpressionParser.ParseLambda(
+            typeof(Action<T1, T2>),
             ParsingConfig.Default,
             false,
-            typeof(Action<T1, T2>),
-            body,
-            ParameterExpressions);
+            ParameterExpressions,
+            null,
+            body);
 
         return (Expression<Action<T1, T2>>)lambda;
     }

--- a/Source/Evoogle.XUnit/Json/ExpressionFuncJsonConverter.cs
+++ b/Source/Evoogle.XUnit/Json/ExpressionFuncJsonConverter.cs
@@ -27,7 +27,7 @@ public sealed class ExpressionFuncJsonConverter<TResult> : JsonConverter<Express
         var lambda = DynamicExpressionParser.ParseLambda(
             ParsingConfig.Default,
             false,
-            typeof(Func<TResult>),
+            typeof(TResult),
             body);
 
         return (Expression<Func<TResult>>)lambda;
@@ -61,9 +61,9 @@ public sealed class ExpressionFuncJsonConverter<T, TResult> : JsonConverter<Expr
         var lambda = DynamicExpressionParser.ParseLambda(
             ParsingConfig.Default,
             false,
-            typeof(Func<T, TResult>),
-            body,
-            ParameterExpressions);
+            ParameterExpressions,
+            typeof(TResult),
+            body);
 
         return (Expression<Func<T, TResult>>)lambda;
     }


### PR DESCRIPTION
## Summary
- ensure ExpressionActionJsonConverter correctly supplies parameter expressions to Dynamic LINQ parser
- ensure ExpressionFuncJsonConverter uses proper ParseLambda overloads

## Testing
- `dotnet build`
- `dotnet test` *(fails: MSBuild TerminalLogger WrapText argument out of range)*

------
https://chatgpt.com/codex/tasks/task_e_689bd6edb378833087150e3d19dd97b6