### PR TITLE
docs: add XML comments to utility classes

### DIFF
--- a/Source/Evoogle.Core/Extensions/DictionaryExtensions.cs
+++ b/Source/Evoogle.Core/Extensions/DictionaryExtensions.cs
@@ -30,6 +30,22 @@ public static class DictionaryExtensions
         throw new KeyNotFoundException(message);
     }
 
+    /// <summary>
+    ///     Attempts to retrieve a value for the specified <paramref name="key"/> from the dictionary.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="dictionary">Dictionary object to call extension method on.</param>
+    /// <param name="key">Key to get the value by in the dictionary.</param>
+    /// <param name="value">
+    ///     When this method returns, contains the value associated with the specified key, if the key is found;
+    ///     otherwise, the provided <paramref name="defaultValue"/>.
+    /// </param>
+    /// <param name="defaultValue">Value to return if the key is not found in the dictionary.</param>
+    /// <returns>
+    ///     <see langword="true"/> if the key exists in the dictionary; otherwise, <see langword="false"/> and
+    ///     <paramref name="value"/> is set to <paramref name="defaultValue"/>.
+    /// </returns>
     public static bool TryGetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, out TValue? value, TValue? defaultValue = default)
     {
         if (dictionary.TryGetValue(key, out value))

--- a/Source/Evoogle.Core/Extensions/Internal/ExtensionDefaults.cs
+++ b/Source/Evoogle.Core/Extensions/Internal/ExtensionDefaults.cs
@@ -12,7 +12,14 @@ namespace Evoogle.Extensions.Internal;
 internal static class ExtensionsDefaults
 {
     #region Fields
+    /// <summary>
+    ///     Text used when representing a <see langword="null"/> value as a string.
+    /// </summary>
     public const string DefaultNullText = "<null>";
+
+    /// <summary>
+    ///     Text used when representing an empty string value.
+    /// </summary>
     public const string DefaultEmptyText = "<empty>";
     #endregion
 }

--- a/Source/Evoogle.Core/NTree/Internal/BreadthFirstEnumerator.cs
+++ b/Source/Evoogle.Core/NTree/Internal/BreadthFirstEnumerator.cs
@@ -21,8 +21,14 @@ internal class BreadthFirstEnumerator<TNode>(TNode node) : IEnumerator<TNode>
     #endregion
 
     #region IEnumerator<TNode> Properties
+    /// <summary>
+    ///     Gets the current node in the enumeration.
+    /// </summary>
     public TNode Current => this.NullableCurrent ?? throw new NullReferenceException($"{nameof(this.Current)} is undefined.");
 
+    /// <summary>
+    ///     Gets or sets the current node in the enumeration, or <see langword="null"/> if the enumeration has not started or has finished.
+    /// </summary>
     public TNode? NullableCurrent { get; set; }
     #endregion
 
@@ -31,6 +37,10 @@ internal class BreadthFirstEnumerator<TNode>(TNode node) : IEnumerator<TNode>
     #endregion
 
     #region IEnumerator Methods
+    /// <summary>
+    ///     Advances the enumerator to the next node in breadth-first order.
+    /// </summary>
+    /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next node; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
     public bool MoveNext()
     {
         if (this.Queue.Count == 0)
@@ -52,6 +62,9 @@ internal class BreadthFirstEnumerator<TNode>(TNode node) : IEnumerator<TNode>
         return true;
     }
 
+    /// <summary>
+    ///     Resets the enumerator to its initial position, before the first node in the collection.
+    /// </summary>
     public void Reset()
     {
         this.Queue.Clear();
@@ -62,6 +75,9 @@ internal class BreadthFirstEnumerator<TNode>(TNode node) : IEnumerator<TNode>
     #endregion
 
     #region IDisposable Methods
+    /// <summary>
+    ///     Releases all resources used by the enumerator.
+    /// </summary>
     public void Dispose()
     { }
     #endregion

--- a/Source/Evoogle.Core/NTree/Internal/DepthFirstEnumerator.cs
+++ b/Source/Evoogle.Core/NTree/Internal/DepthFirstEnumerator.cs
@@ -21,8 +21,14 @@ internal class DepthFirstEnumerator<TNode>(TNode node) : IEnumerator<TNode>
     #endregion
 
     #region IEnumerator<TNode> Properties
+    /// <summary>
+    ///     Gets the current node in the enumeration.
+    /// </summary>
     public TNode Current => this.NullableCurrent ?? throw new NullReferenceException($"{nameof(this.Current)} is undefined.");
 
+    /// <summary>
+    ///     Gets or sets the current node in the enumeration, or <see langword="null"/> if the enumeration has not started or has finished.
+    /// </summary>
     public TNode? NullableCurrent { get; set; }
     #endregion
 
@@ -31,6 +37,10 @@ internal class DepthFirstEnumerator<TNode>(TNode node) : IEnumerator<TNode>
     #endregion
 
     #region IEnumerator Methods
+    /// <summary>
+    ///     Advances the enumerator to the next node in depth-first order.
+    /// </summary>
+    /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next node; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
     public bool MoveNext()
     {
         if (this.Stack.Count == 0)
@@ -53,6 +63,9 @@ internal class DepthFirstEnumerator<TNode>(TNode node) : IEnumerator<TNode>
         return true;
     }
 
+    /// <summary>
+    ///     Resets the enumerator to its initial position, before the first node in the collection.
+    /// </summary>
     public void Reset()
     {
         this.Stack.Clear();
@@ -63,6 +76,9 @@ internal class DepthFirstEnumerator<TNode>(TNode node) : IEnumerator<TNode>
     #endregion
 
     #region IDisposable Methods
+    /// <summary>
+    ///     Releases all resources used by the enumerator.
+    /// </summary>
     public void Dispose()
     { }
     #endregion

--- a/Source/Evoogle.Core/Reflection/StaticReflection.cs
+++ b/Source/Evoogle.Core/Reflection/StaticReflection.cs
@@ -13,20 +13,94 @@ namespace Evoogle.Reflection;
 public static class StaticReflection
 {
     #region Methods
+    /// <summary>
+    ///     Gets the member name represented by a strongly-typed expression.
+    /// </summary>
+    /// <typeparam name="T">Type containing the member.</typeparam>
+    /// <param name="expression">Expression selecting the member.</param>
+    /// <param name="throwOnUnsupported">
+    ///     If <see langword="true"/>, throws an <see cref="ArgumentException"/> when the expression type is unsupported;
+    ///     otherwise, returns a placeholder name.
+    /// </param>
+    /// <returns>The name of the member.</returns>
     public static string GetMemberName<T>(Expression<Func<T, object>> expression, bool throwOnUnsupported = true) => GetMemberName(expression.Body, throwOnUnsupported);
 
+    /// <summary>
+    ///     Gets the member name represented by a strongly-typed expression.
+    /// </summary>
+    /// <typeparam name="T">Type containing the member.</typeparam>
+    /// <typeparam name="TResult">Return type of the member.</typeparam>
+    /// <param name="expression">Expression selecting the member.</param>
+    /// <param name="throwOnUnsupported">
+    ///     If <see langword="true"/>, throws an <see cref="ArgumentException"/> when the expression type is unsupported;
+    ///     otherwise, returns a placeholder name.
+    /// </param>
+    /// <returns>The name of the member.</returns>
     public static string GetMemberName<T, TResult>(Expression<Func<T, TResult>> expression, bool throwOnUnsupported = true) => GetMemberName(expression.Body, throwOnUnsupported);
 
+    /// <summary>
+    ///     Gets the member name represented by a strongly-typed action expression.
+    /// </summary>
+    /// <typeparam name="T">Type containing the member.</typeparam>
+    /// <param name="expression">Expression selecting the member.</param>
+    /// <param name="throwOnUnsupported">
+    ///     If <see langword="true"/>, throws an <see cref="ArgumentException"/> when the expression type is unsupported;
+    ///     otherwise, returns a placeholder name.
+    /// </param>
+    /// <returns>The name of the member.</returns>
     public static string GetMemberName<T>(Expression<Action<T>> expression, bool throwOnUnsupported = true) => GetMemberName(expression.Body, throwOnUnsupported);
 
+    /// <summary>
+    ///     Gets the member name represented by a strongly-typed expression for the specified instance.
+    /// </summary>
+    /// <typeparam name="T">Type containing the member.</typeparam>
+    /// <param name="_">Instance providing the generic type argument.</param>
+    /// <param name="expression">Expression selecting the member.</param>
+    /// <param name="throwOnUnsupported">
+    ///     If <see langword="true"/>, throws an <see cref="ArgumentException"/> when the expression type is unsupported;
+    ///     otherwise, returns a placeholder name.
+    /// </param>
+    /// <returns>The name of the member.</returns>
     public static string GetMemberName<T>(this T _, Expression<Func<T, object>> expression, bool throwOnUnsupported = true) => GetMemberName(expression.Body, throwOnUnsupported);
 
+    /// <summary>
+    ///     Gets the member name represented by a strongly-typed expression for the specified instance.
+    /// </summary>
+    /// <typeparam name="T">Type containing the member.</typeparam>
+    /// <typeparam name="TResult">Return type of the member.</typeparam>
+    /// <param name="_">Instance providing the generic type argument.</param>
+    /// <param name="expression">Expression selecting the member.</param>
+    /// <param name="throwOnUnsupported">
+    ///     If <see langword="true"/>, throws an <see cref="ArgumentException"/> when the expression type is unsupported;
+    ///     otherwise, returns a placeholder name.
+    /// </param>
+    /// <returns>The name of the member.</returns>
     public static string GetMemberName<T, TResult>(this T _, Expression<Func<T, TResult>> expression, bool throwOnUnsupported = true) => GetMemberName(expression.Body, throwOnUnsupported);
 
+    /// <summary>
+    ///     Gets the member name represented by a strongly-typed action expression for the specified instance.
+    /// </summary>
+    /// <typeparam name="T">Type containing the member.</typeparam>
+    /// <param name="_">Instance providing the generic type argument.</param>
+    /// <param name="expression">Expression selecting the member.</param>
+    /// <param name="throwOnUnsupported">
+    ///     If <see langword="true"/>, throws an <see cref="ArgumentException"/> when the expression type is unsupported;
+    ///     otherwise, returns a placeholder name.
+    /// </param>
+    /// <returns>The name of the member.</returns>
     public static string GetMemberName<T>(this T _, Expression<Action<T>> expression, bool throwOnUnsupported = true) => GetMemberName(expression.Body, throwOnUnsupported);
     #endregion
 
     #region Implementation Methods
+    /// <summary>
+    ///     Core logic that extracts the member name from an expression tree.
+    /// </summary>
+    /// <param name="expression">Expression tree to analyze.</param>
+    /// <param name="throwOnUnsupported">
+    ///     If <see langword="true"/>, throws an <see cref="ArgumentException"/> when the expression type is unsupported;
+    ///     otherwise, returns a placeholder name.
+    /// </param>
+    /// <returns>The name of the member represented by the expression.</returns>
     internal static string GetMemberName(Expression expression, bool throwOnUnsupported)
     {
         switch (expression)


### PR DESCRIPTION
## Summary
- document dictionary helper returning default when key missing
- add missing XML docs for StaticReflection APIs
- document internal tree traversal enumerators and extension defaults

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac3d273c83309207972024c1ebae