### PR TITLE
Add XML documentation for Utf8JsonWriter extensions

### DIFF
--- a/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.Action.cs
+++ b/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.Action.cs
@@ -11,6 +11,20 @@ namespace Evoogle.Json;
 public static partial class Utf8JsonWriterExtensions
 {
     #region TryWritePropertyWithAction Extension Methods
+    /// <summary>
+    ///     Attempts to write a property using a custom action when the serializer options
+    ///     permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="writeAction">The action that writes the value.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyWithAction<T>
     (
         this Utf8JsonWriter writer,
@@ -36,6 +50,20 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable property using a custom action when the serializer
+    ///     options permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="nullableValue">The value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="writeAction">The action that writes the value.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyWithAction<T>
     (
         this Utf8JsonWriter writer,
@@ -61,6 +89,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a reference type property using a custom action when the serializer
+    ///     options permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="obj">The object to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="writeAction">The action that writes the value.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyWithAction<T>
     (
         this Utf8JsonWriter writer,

--- a/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.Boolean.cs
+++ b/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.Boolean.cs
@@ -11,6 +11,17 @@ namespace Evoogle.Json;
 public static partial class Utf8JsonWriterExtensions
 {
     #region TryWritePropertyAsBoolean Extension Methods
+    /// <summary>
+    ///     Attempts to write a boolean property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The boolean value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsBoolean(this Utf8JsonWriter writer, string propertyName, bool value, JsonSerializerOptions options, EqualityComparer<bool>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -23,6 +34,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable boolean property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The boolean value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsBoolean(this Utf8JsonWriter writer, string propertyName, bool? value, JsonSerializerOptions options, EqualityComparer<bool>? equalityComparer = null)
     {
         return writer.TryWriteProperty

--- a/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.Converter.cs
+++ b/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.Converter.cs
@@ -11,6 +11,19 @@ namespace Evoogle.Json;
 public static partial class Utf8JsonWriterExtensions
 {
     #region TryWriteWithConverter Extension Methods
+    /// <summary>
+    ///     Attempts to write an enum value using the specified converter when the serializer
+    ///     options permit it.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="value">The enum value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="converter">The converter used to write the value.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the value was written; otherwise, <c>false</c>.</returns>
     public static bool TryWriteWithConverter<TEnum>
     (
         this Utf8JsonWriter writer,
@@ -33,6 +46,19 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable enum value using the specified converter when the
+    ///     serializer options permit it.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="value">The enum value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="converter">The converter used to write the value.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the value was written; otherwise, <c>false</c>.</returns>
     public static bool TryWriteWithConverter<TEnum>
     (
         this Utf8JsonWriter writer,
@@ -55,6 +81,15 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a <see cref="Type"/> value using the specified converter when the
+    ///     serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="type">The type to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="converter">The converter used to write the value.</param>
+    /// <returns><c>true</c> if the value was written; otherwise, <c>false</c>.</returns>
     public static bool TryWriteWithConverter
     (
         this Utf8JsonWriter writer,
@@ -76,6 +111,20 @@ public static partial class Utf8JsonWriterExtensions
     #endregion
 
     #region TryWritePropertyWithConverter Extension Methods
+    /// <summary>
+    ///     Attempts to write an enum property using the specified converter when the serializer
+    ///     options permit it.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The enum value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="converter">The converter used to write the value.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyWithConverter<TEnum>
     (
         this Utf8JsonWriter writer,
@@ -101,6 +150,20 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable enum property using the specified converter when the
+    ///     serializer options permit it.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The enum value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="converter">The converter used to write the value.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyWithConverter<TEnum>
     (
         this Utf8JsonWriter writer,
@@ -126,6 +189,16 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a <see cref="Type"/> property using the specified converter when the
+    ///     serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="type">The type to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="converter">The converter used to write the value.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyWithConverter
     (
         this Utf8JsonWriter writer,

--- a/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.Number.cs
+++ b/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.Number.cs
@@ -11,6 +11,17 @@ namespace Evoogle.Json;
 public static partial class Utf8JsonWriterExtensions
 {
     #region TryWritePropertyAsNumber Extension Methods
+    /// <summary>
+    ///     Attempts to write a decimal property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The decimal value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsNumber(this Utf8JsonWriter writer, string propertyName, decimal value, JsonSerializerOptions options, EqualityComparer<decimal>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -23,6 +34,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable decimal property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The decimal value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsNumber(this Utf8JsonWriter writer, string propertyName, decimal? value, JsonSerializerOptions options, EqualityComparer<decimal>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -35,6 +57,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a double property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The double value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsNumber(this Utf8JsonWriter writer, string propertyName, double value, JsonSerializerOptions options, EqualityComparer<double>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -47,6 +80,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable double property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The double value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsNumber(this Utf8JsonWriter writer, string propertyName, double? value, JsonSerializerOptions options, EqualityComparer<double>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -59,6 +103,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a float property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The float value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsNumber(this Utf8JsonWriter writer, string propertyName, float value, JsonSerializerOptions options, EqualityComparer<float>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -71,6 +126,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable float property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The float value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsNumber(this Utf8JsonWriter writer, string propertyName, float? value, JsonSerializerOptions options, EqualityComparer<float>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -83,6 +149,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write an integer property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The integer value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsNumber(this Utf8JsonWriter writer, string propertyName, int value, JsonSerializerOptions options, EqualityComparer<int>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -95,6 +172,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable integer property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The integer value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsNumber(this Utf8JsonWriter writer, string propertyName, int? value, JsonSerializerOptions options, EqualityComparer<int>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -107,6 +195,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a long property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The long value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsNumber(this Utf8JsonWriter writer, string propertyName, long value, JsonSerializerOptions options, EqualityComparer<long>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -119,6 +218,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable long property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The long value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsNumber(this Utf8JsonWriter writer, string propertyName, long? value, JsonSerializerOptions options, EqualityComparer<long>? equalityComparer = null)
     {
         return writer.TryWriteProperty

--- a/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.Serializer.cs
+++ b/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.Serializer.cs
@@ -11,6 +11,18 @@ namespace Evoogle.Json;
 public static partial class Utf8JsonWriterExtensions
 {
     #region TryWriteWithSerializer Extension Methods
+    /// <summary>
+    ///     Attempts to serialize a value using <see cref="JsonSerializer"/> when the serializer
+    ///     options permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to serialize.</typeparam>
+    /// <param name="writer">The writer to which the value will be serialized.</param>
+    /// <param name="value">The value to serialize.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the value was written; otherwise, <c>false</c>.</returns>
     public static bool TryWriteWithSerializer<T>
     (
         this Utf8JsonWriter writer,
@@ -32,6 +44,18 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to serialize a nullable value using <see cref="JsonSerializer"/> when the
+    ///     serializer options permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to serialize.</typeparam>
+    /// <param name="writer">The writer to which the value will be serialized.</param>
+    /// <param name="nullableValue">The value to serialize, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the value was written; otherwise, <c>false</c>.</returns>
     public static bool TryWriteWithSerializer<T>
     (
         this Utf8JsonWriter writer,
@@ -53,6 +77,15 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to serialize a reference type using <see cref="JsonSerializer"/> when the
+    ///     serializer options permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to serialize.</typeparam>
+    /// <param name="writer">The writer to which the value will be serialized.</param>
+    /// <param name="obj">The object to serialize.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <returns><c>true</c> if the value was written; otherwise, <c>false</c>.</returns>
     public static bool TryWriteWithSerializer<T>
     (
         this Utf8JsonWriter writer,
@@ -74,6 +107,19 @@ public static partial class Utf8JsonWriterExtensions
     #endregion
 
     #region TryWritePropertyWithSerializer Extension Methods
+    /// <summary>
+    ///     Attempts to serialize a value as a property using <see cref="JsonSerializer"/>
+    ///     when the serializer options permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to serialize.</typeparam>
+    /// <param name="writer">The writer to which the value will be serialized.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The value to serialize.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyWithSerializer<T>
     (
         this Utf8JsonWriter writer,
@@ -98,6 +144,19 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to serialize a nullable value as a property using
+    ///     <see cref="JsonSerializer"/> when the serializer options permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to serialize.</typeparam>
+    /// <param name="writer">The writer to which the value will be serialized.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="nullableValue">The value to serialize, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyWithSerializer<T>
     (
         this Utf8JsonWriter writer,
@@ -122,6 +181,16 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to serialize a reference type as a property using
+    ///     <see cref="JsonSerializer"/> when the serializer options permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to serialize.</typeparam>
+    /// <param name="writer">The writer to which the value will be serialized.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="obj">The object to serialize.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyWithSerializer<T>
     (
         this Utf8JsonWriter writer,

--- a/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.String.cs
+++ b/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.String.cs
@@ -12,6 +12,20 @@ namespace Evoogle.Json;
 public static partial class Utf8JsonWriterExtensions
 {
     #region TryWritePropertyAsString Extension Methods
+    /// <summary>
+    ///     Attempts to write a <see cref="DateTime"/> property when the serializer options
+    ///     permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The date and time value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <param name="format">The format string to use.</param>
+    /// <param name="formatProvider">The format provider to use.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, DateTime value, JsonSerializerOptions options, EqualityComparer<DateTime>? equalityComparer = null, string format = "O", IFormatProvider? formatProvider = null)
     {
         return writer.TryWriteProperty
@@ -24,6 +38,20 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable <see cref="DateTime"/> property when the serializer
+    ///     options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The date and time value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <param name="format">The format string to use.</param>
+    /// <param name="formatProvider">The format provider to use.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, DateTime? value, JsonSerializerOptions options, EqualityComparer<DateTime>? equalityComparer = null, string format = "O", IFormatProvider? formatProvider = null)
     {
         return writer.TryWriteProperty
@@ -36,6 +64,20 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a <see cref="DateTimeOffset"/> property when the serializer options
+    ///     permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The date and time offset value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <param name="format">The format string to use.</param>
+    /// <param name="formatProvider">The format provider to use.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, DateTimeOffset value, JsonSerializerOptions options, EqualityComparer<DateTimeOffset>? equalityComparer = null, string format = "O", IFormatProvider? formatProvider = null)
     {
         return writer.TryWriteProperty
@@ -48,6 +90,20 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable <see cref="DateTimeOffset"/> property when the serializer
+    ///     options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The date and time offset value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <param name="format">The format string to use.</param>
+    /// <param name="formatProvider">The format provider to use.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, DateTimeOffset? value, JsonSerializerOptions options, EqualityComparer<DateTimeOffset>? equalityComparer = null, string format = "O", IFormatProvider? formatProvider = null)
     {
         return writer.TryWriteProperty
@@ -60,6 +116,18 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write an enum property as a string when the serializer options permit it.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The enum value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString<TEnum>(this Utf8JsonWriter writer, string propertyName, TEnum value, JsonSerializerOptions options, EqualityComparer<TEnum>? equalityComparer = null)
         where TEnum : struct, Enum
     {
@@ -73,6 +141,19 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable enum property as a string when the serializer options
+    ///     permit it.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The enum value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString<TEnum>(this Utf8JsonWriter writer, string propertyName, TEnum? value, JsonSerializerOptions options, EqualityComparer<TEnum>? equalityComparer = null)
         where TEnum : struct, Enum
     {
@@ -86,6 +167,17 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a <see cref="Guid"/> property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The <see cref="Guid"/> value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, Guid value, JsonSerializerOptions options, EqualityComparer<Guid>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -98,6 +190,18 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable <see cref="Guid"/> property when the serializer options
+    ///     permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The <see cref="Guid"/> value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, Guid? value, JsonSerializerOptions options, EqualityComparer<Guid>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -110,6 +214,14 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a string property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The string value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, string? value, JsonSerializerOptions options)
     {
         return writer.TryWriteProperty
@@ -121,6 +233,19 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a <see cref="TimeSpan"/> property when the serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The time span value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <param name="format">The format string to use.</param>
+    /// <param name="formatProvider">The format provider to use.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, TimeSpan value, JsonSerializerOptions options, EqualityComparer<TimeSpan>? equalityComparer = null, string format = "c", IFormatProvider? formatProvider = null)
     {
         return writer.TryWriteProperty
@@ -133,6 +258,20 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable <see cref="TimeSpan"/> property when the serializer
+    ///     options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The time span value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <param name="format">The format string to use.</param>
+    /// <param name="formatProvider">The format provider to use.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, TimeSpan? value, JsonSerializerOptions options, EqualityComparer<TimeSpan>? equalityComparer = null, string format = "c", IFormatProvider? formatProvider = null)
     {
         return writer.TryWriteProperty
@@ -145,6 +284,18 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a <see cref="Ulid"/> property as a JSON string when the serializer
+    ///     options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The <see cref="Ulid"/> value to write.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, Ulid value, JsonSerializerOptions options, EqualityComparer<Ulid>? equalityComparer = null)
     {
         return writer.TryWriteProperty
@@ -161,6 +312,18 @@ public static partial class Utf8JsonWriterExtensions
         );
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable <see cref="Ulid"/> property as a JSON string when the
+    ///     serializer options permit it.
+    /// </summary>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The <see cref="Ulid"/> value to write, if present.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWritePropertyAsString(this Utf8JsonWriter writer, string propertyName, Ulid? value, JsonSerializerOptions options, EqualityComparer<Ulid>? equalityComparer = null)
     {
         return writer.TryWriteProperty

--- a/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.cs
+++ b/Source/Evoogle.Core/Json/Utf8JsonWriterExtensions.cs
@@ -8,9 +8,28 @@ using System.Text.Json.Serialization;
 
 namespace Evoogle.Json;
 
+/// <summary>
+///     Provides helper methods for <see cref="Utf8JsonWriter"/> that only write values when
+///     the current <see cref="JsonSerializerOptions"/> indicate they should be included.
+/// </summary>
 public static partial class Utf8JsonWriterExtensions
 {
     #region TryWrite Methods
+
+    /// <summary>
+    ///     Attempts to write a value using the specified <paramref name="writeAction"/> when the
+    ///     current <paramref name="options"/> permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options that control when values are ignored.</param>
+    /// <param name="writeAction">The action that writes the value to the writer.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to determine whether the value is the default and should be
+    ///     ignored.
+    /// </param>
+    /// <returns><c>true</c> if the value was written; otherwise, <c>false</c>.</returns>
     public static bool TryWrite<T>
     (
         this Utf8JsonWriter writer,
@@ -36,6 +55,20 @@ public static partial class Utf8JsonWriterExtensions
         return true;
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable value using the specified <paramref name="writeAction"/>
+    ///     when the provided <paramref name="options"/> allow it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="nullableValue">The value to write, if present.</param>
+    /// <param name="options">The serializer options that control when values are ignored.</param>
+    /// <param name="writeAction">The action that writes the value to the writer.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to determine whether the value is the default and should be
+    ///     ignored.
+    /// </param>
+    /// <returns><c>true</c> if the value was written; otherwise, <c>false</c>.</returns>
     public static bool TryWrite<T>
     (
         this Utf8JsonWriter writer,
@@ -69,6 +102,16 @@ public static partial class Utf8JsonWriterExtensions
         return true;
     }
 
+    /// <summary>
+    ///     Attempts to write a reference type value using the specified
+    ///     <paramref name="writeAction"/> when the supplied <paramref name="options"/> permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="obj">The object to write.</param>
+    /// <param name="options">The serializer options that control when values are ignored.</param>
+    /// <param name="writeAction">The action that writes the value to the writer.</param>
+    /// <returns><c>true</c> if the value was written; otherwise, <c>false</c>.</returns>
     public static bool TryWrite<T>
     (
         this Utf8JsonWriter writer,
@@ -102,6 +145,22 @@ public static partial class Utf8JsonWriterExtensions
     #endregion
 
     #region TryWriteProperty Extension Methods
+
+    /// <summary>
+    ///     Attempts to write a property using the supplied <paramref name="writeAction"/> when
+    ///     the provided <paramref name="options"/> indicate the value should be included.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options that control when values are ignored.</param>
+    /// <param name="writeAction">The action that writes the property and value.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to determine whether the value is the default and should be
+    ///     ignored.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWriteProperty<T>
     (
         this Utf8JsonWriter writer,
@@ -128,6 +187,22 @@ public static partial class Utf8JsonWriterExtensions
         return true;
     }
 
+    /// <summary>
+    ///     Attempts to write a nullable property using the supplied
+    ///     <paramref name="writeAction"/> when the
+    ///     <paramref name="options"/> allow it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="nullableValue">The value to write, if present.</param>
+    /// <param name="options">The serializer options that control when values are ignored.</param>
+    /// <param name="writeAction">The action that writes the property and value.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to determine whether the value is the default and should be
+    ///     ignored.
+    /// </param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWriteProperty<T>
     (
         this Utf8JsonWriter writer,
@@ -163,6 +238,17 @@ public static partial class Utf8JsonWriterExtensions
         return true;
     }
 
+    /// <summary>
+    ///     Attempts to write a property for a reference type using the supplied
+    ///     <paramref name="writeAction"/> when the <paramref name="options"/> permit it.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to write.</typeparam>
+    /// <param name="writer">The writer to which the value will be written.</param>
+    /// <param name="propertyName">The name of the JSON property.</param>
+    /// <param name="obj">The object to write.</param>
+    /// <param name="options">The serializer options that control when values are ignored.</param>
+    /// <param name="writeAction">The action that writes the property and value.</param>
+    /// <returns><c>true</c> if the property was written; otherwise, <c>false</c>.</returns>
     public static bool TryWriteProperty<T>
     (
         this Utf8JsonWriter writer,
@@ -198,6 +284,20 @@ public static partial class Utf8JsonWriterExtensions
     #endregion
 
     #region Implementation Methods
+    /// <summary>
+    ///     Determines whether a struct value should be written based on the serializer options
+    ///     and an optional equality comparer.
+    /// </summary>
+    /// <typeparam name="T">The type of the value being evaluated.</typeparam>
+    /// <param name="value">The value to inspect.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns>
+    ///     A tuple indicating whether the value should be written and whether it was the default
+    ///     value.
+    /// </returns>
     private static (bool ShouldWrite, bool IsDefault) ShouldWrite<T>(T value, JsonSerializerOptions options, EqualityComparer<T>? equalityComparer)
         where T : struct
     {
@@ -218,6 +318,19 @@ public static partial class Utf8JsonWriterExtensions
         };
     }
 
+    /// <summary>
+    ///     Determines whether a nullable struct value should be written based on the serializer
+    ///     options and an optional equality comparer.
+    /// </summary>
+    /// <typeparam name="T">The type of the value being evaluated.</typeparam>
+    /// <param name="nullableValue">The value to inspect.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <param name="equalityComparer">
+    ///     Optional comparer used to detect default values.
+    /// </param>
+    /// <returns>
+    ///     A tuple indicating whether the value should be written and whether it was <c>null</c>.
+    /// </returns>
     private static (bool ShouldWrite, bool IsNull) ShouldWrite<T>(T? nullableValue, JsonSerializerOptions options, EqualityComparer<T>? equalityComparer)
         where T : struct
     {
@@ -251,6 +364,17 @@ public static partial class Utf8JsonWriterExtensions
         }
     }
 
+    /// <summary>
+    ///     Determines whether a reference type value should be written based on the serializer
+    ///     options.
+    /// </summary>
+    /// <typeparam name="T">The type of the value being evaluated.</typeparam>
+    /// <param name="obj">The object to inspect.</param>
+    /// <param name="options">The serializer options that control ignore conditions.</param>
+    /// <returns>
+    ///     A tuple indicating whether the value should be written and whether it was
+    ///     <c>null</c>.
+    /// </returns>
     private static (bool ShouldWrite, bool IsNull) ShouldWrite<T>(T? obj, JsonSerializerOptions options)
         where T : class
     {


### PR DESCRIPTION
## Summary
- document `Utf8JsonWriterExtensions` partial class and helper methods
- add comprehensive XML comments for Boolean, numeric, string, action, serializer, and converter extensions

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ae3322448330a24a6adaf5485965